### PR TITLE
Make the type of the eval-after-load FILE argument selectable

### DIFF
--- a/ChangeLog.org
+++ b/ChangeLog.org
@@ -13,6 +13,12 @@
 
 - Removed old namespace, =el-init:= ([[https://github.com/HKey/el-init/issues/6][#6]])
 
+- Added an option, =el-init-lazy-feature-type= ([[https://github.com/HKey/el-init/pull/9][#9]]) \\
+  This option controls the =file= argument type of =eval-after-load= in
+  =el-init-require/lazy=.
+  =el-init-require/lazy= was changed to use symbol as default.
+
+
 ** 0.1.4
 
 [[https://github.com/HKey/el-init/compare/0.1.3...0.1.4][commits]]

--- a/test/el-init-test.el
+++ b/test/el-init-test.el
@@ -229,18 +229,25 @@
 (ert-deftest el-init-test-require/lazy ()
   (let ((dir (el-init-test-get-path "test-inits/wrappers/lazy")))
     (let* ((basic  (concat dir "/basic"))
-           (libdir (concat basic "/lib")))
-      (el-init-test-sandbox
-        (add-to-list 'load-path libdir)
-        (el-init-load basic
-                      :subdirectories '(".")
-                      :wrappers (list #'el-init-require/lazy))
+           (libdir (concat basic "/lib"))
+           (fn     (lambda ()
+                     (el-init-test-sandbox
+                       (add-to-list 'load-path libdir)
+                       (el-init-load basic
+                                     :subdirectories '(".")
+                                     :wrappers (list #'el-init-require/lazy))
 
-        (should-not (featurep 'init-lazy-lib-dummy))
+                       (should-not (featurep 'init-lazy-lib-dummy))
 
-        (require 'lib-dummy)
+                       (require 'lib-dummy)
 
-        (should (featurep 'init-lazy-lib-dummy))))
+                       (should (featurep 'init-lazy-lib-dummy))))))
+
+      (let ((el-init-lazy-feature-type 'string))
+        (funcall fn))
+
+      (let ((el-init-lazy-feature-type 'symbol))
+        (funcall fn)))
 
     ;; recursive loading
     ;;


### PR DESCRIPTION
- Add an option to control it
- Change the default type to symbol

There is a little difference of evaluation order between symbol and string.
So it should be selectable.
