### PR TITLE
Follow ert-runner 0.7.0

### DIFF
--- a/Cask
+++ b/Cask
@@ -4,5 +4,5 @@
 (package-file "el-init.el")
 
 (development
- (depends-on "ert-runner")
+ (depends-on "ert-runner" "0.7.0")
  (depends-on "undercover"))

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ EMACS ?= emacs
 CASK  ?= cask
 MAKE  ?= make
 
-.PHONY: clean compile test full-test coverage
+.PHONY: clean compile test compiled-test full-test coverage
 
 clean:
 	${CASK} clean-elc
@@ -18,13 +18,16 @@ compile:
 	${CASK} exec ${EMACS} -Q -batch -L . -L ./test -f batch-byte-compile  ./test/*.el
 
 test:
-	${CASK} exec ert-runner
+	${CASK} exec ert-runner test/el-init-test.el
+
+compiled-test:
+	${CASK} exec ert-runner test/el-init-test.elc
 
 full-test:
 	${MAKE} clean
 	${MAKE} test
 	${MAKE} compile
-	${MAKE} test
+	${MAKE} compiled-test
 
 # do not compile when using undercover.el
 coverage:


### PR DESCRIPTION
Since ert-runner 0.7.0, it finds test files recursively.
So the test commands need to specify the test file.
Before this commit, ert-runner had loaded wrong files below:
- init-test.el
- init-freebsd-test.el
- init-linux-test.el
- init-mac-test.el
- init-windows-test.el
