### PR TITLE
Respect debug-on-error

### DIFF
--- a/ChangeLog.org
+++ b/ChangeLog.org
@@ -1,5 +1,16 @@
 * el-init ChangeLog
 
+** dev
+
+[[https://github.com/HKey/el-init/compare/0.1.5...master][commits]]
+
+- Following =require= wrappers now respect =debug-on-error= ([[https://github.com/HKey/el-init/pull/12][#12]]). \\
+  This is useful when using =emacs --debug-init=.
+  - =el-init-require/record-error=
+  - =el-init-require/ignore-errors=
+  - =el-init-require/record-eval-after-load-error=
+  - =el-init-require/compile-old-library=
+
 ** 0.1.5
 
 [[https://github.com/HKey/el-init/compare/0.1.4...0.1.5][commits]]

--- a/test/el-init-test-helper.el
+++ b/test/el-init-test-helper.el
@@ -24,4 +24,14 @@
 (defun el-init-test-get-path (path)
   (expand-file-name path el-init-test-test-directory))
 
+(defmacro el-init-test-dont-debug (&rest body)
+  "Prevent invoking debuggers.
+This macro is used to run tests containing `condition-case-unless-debug'.
+Because when running tests with ert, it binds `debug-on-error' to t.
+When `debug-on-error' is t, `condition-case-unless-debug' doesn't behave
+as `condition-case'."
+  (declare (indent 0))
+  `(let ((debug-on-error nil))
+     ,@body))
+
 (provide 'el-init-test-helper)

--- a/test/el-init-test-helper.el
+++ b/test/el-init-test-helper.el
@@ -29,9 +29,12 @@
 This macro is used to run tests containing `condition-case-unless-debug'.
 Because when running tests with ert, it binds `debug-on-error' to t.
 When `debug-on-error' is t, `condition-case-unless-debug' doesn't behave
-as `condition-case'."
+as `condition-case'.
+This macro also operates for edebug.
+Edebug is used by undercover.el."
   (declare (indent 0))
-  `(let ((debug-on-error nil))
+  `(let ((debug-on-error nil)
+         (edebug-on-error nil))
      ,@body))
 
 (provide 'el-init-test-helper)

--- a/test/el-init-test.el
+++ b/test/el-init-test.el
@@ -138,39 +138,42 @@
 
 (ert-deftest el-init-test-require/record-error ()
   (el-init-test-sandbox
-   (el-init-load (el-init-test-get-path "test-inits/wrappers/error")
-                 :subdirectories '(".")
-                 :wrappers (list #'el-init-require/record-error))
+    (el-init-test-dont-debug
+      (el-init-load (el-init-test-get-path "test-inits/wrappers/error")
+                    :subdirectories '(".")
+                    :wrappers (list #'el-init-require/record-error)))
 
-   (should (equal (el-init-get-record 'init-test-error
-                                      'el-init-require/record-error)
-                  '(error "Error")))))
+    (should (equal (el-init-get-record 'init-test-error
+                                       'el-init-require/record-error)
+                   '(error "Error")))))
 
 (ert-deftest el-init-test-require/ignore-errors ()
   (el-init-test-sandbox
-   (let ((caught nil))
-     (condition-case e
-         (el-init-load (el-init-test-get-path "test-inits/wrappers/error")
-                       :subdirectories '(".")
-                       :wrappers (list #'el-init-require/ignore-errors))
-       (error (setq caught e)))
+    (let ((caught nil))
+      (condition-case e
+          (el-init-test-dont-debug
+            (el-init-load (el-init-test-get-path "test-inits/wrappers/error")
+                          :subdirectories '(".")
+                          :wrappers (list #'el-init-require/ignore-errors)))
+        (error (setq caught e)))
 
-     (should (null caught)))))
+      (should (null caught)))))
 
 (ert-deftest el-init-test-require/record-eval-after-load-error ()
   (el-init-test-sandbox
-   (el-init-load (el-init-test-get-path "test-inits/wrappers/eval-after-load")
-                 :subdirectories '("error")
-                 :wrappers (list #'el-init-require/record-eval-after-load-error))
-   (add-to-list 'load-path
-                (el-init-test-get-path "test-inits/wrappers/eval-after-load"))
-   (require 'init-test-library)
+    (el-init-test-dont-debug
+      (el-init-load (el-init-test-get-path "test-inits/wrappers/eval-after-load")
+                    :subdirectories '("error")
+                    :wrappers (list #'el-init-require/record-eval-after-load-error))
+      (add-to-list 'load-path
+                   (el-init-test-get-path "test-inits/wrappers/eval-after-load"))
+      (require 'init-test-library))
 
-   (let ((record (el-init-get-record 'init-test-error
-                                     'el-init-require/record-eval-after-load-error)))
-     (should (= (length record) 1))
-     (should (equal (plist-get (cl-first record) :error)
-                    '(error "Error"))))))
+    (let ((record (el-init-get-record 'init-test-error
+                                      'el-init-require/record-eval-after-load-error)))
+      (should (= (length record) 1))
+      (should (equal (plist-get (cl-first record) :error)
+                     '(error "Error"))))))
 
 (ert-deftest el-init-test-require/system-case ()
   (el-init-test-sandbox


### PR DESCRIPTION
Using `condition-case-unless-debug` to handle errors is useful when using `emacs --debug-init`.
